### PR TITLE
FAT-702-73773 Fixed wrong identification person authorization

### DIFF
--- a/src/Plugin/os2web/NemloginAuthProvider/Idp.php
+++ b/src/Plugin/os2web/NemloginAuthProvider/Idp.php
@@ -94,8 +94,9 @@ class Idp extends AuthProviderBase {
   public function isAuthenticatedPerson() {
     // We have to fetch value via parent, in order to avoid possible deletion
     // of value if "fetchOnce" flag is TRUE.
-    if (!empty(parent::fetchValue('cpr'))) {
-      return TRUE;
+    // It's important that CVR key is empty. There could be both keys in case of
+    // using key files.
+    if (!empty(parent::fetchValue('cpr')) && empty(parent::fetchValue('cvr'))) {
     }
 
     return FALSE;


### PR DESCRIPTION
There could be both CPR and CVR keys in case of using nemlogin key files for authorization