### PR TITLE
Declare AuthProviderRoutes class property

### DIFF
--- a/src/Routing/AuthProviderRoutes.php
+++ b/src/Routing/AuthProviderRoutes.php
@@ -13,6 +13,13 @@ use Symfony\Component\Routing\Route;
 class AuthProviderRoutes implements ContainerInjectionInterface {
 
   /**
+   * The AuthProviderManager.
+   *
+   * @var \Drupal\Component\Plugin\PluginManagerInterface
+   */
+  protected $authProviderManager;
+
+  /**
    * Constructs a new AuthProvider route subscriber.
    *
    * @param \Drupal\Component\Plugin\PluginManagerInterface $authProviderManager


### PR DESCRIPTION
Handles 

```
Deprecated function: Creation of dynamic property 
Drupal\os2web_nemlogin\Routing\AuthProviderRoutes::$authProviderManager
is deprecated in Drupal\os2web_nemlogin\Routing\AuthProviderRoutes->__construct() ...
```